### PR TITLE
Add mapping for PC Financial Mastercards (Canada)

### DIFF
--- a/csv2ofx/mappings/pcmastercard.py
+++ b/csv2ofx/mappings/pcmastercard.py
@@ -1,0 +1,15 @@
+"""
+For PC Financial Mastercards
+https://www.pcfinancial.ca/en/credit-cards
+"""
+from operator import itemgetter
+
+mapping = {
+    'has_header': True,
+    'bank': 'PC Financial',
+    'currency': 'CAD',
+    'account': 'Mastercard',
+    'date': itemgetter('Date'),
+    'amount': lambda r: float(r['Amount']) * -1.0,
+    'payee': itemgetter('"Merchant Name"'),
+}


### PR DESCRIPTION
An example of their very basic CSV export:

```
"Merchant Name","Card Used For Transaction","Date","Time","Amount"
"Mobil","**** 1234","01/10/2019","06:50 PM","36.33"
"APL*ITUNES.COM/BILL","**** 4567","12/15/2018","05:08 PM","13.98"
```